### PR TITLE
Add swim statistics aggregation and export

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,8 @@ CSV_HEADERS = [
     "Running Activity Count", "Running Distance (km)", "Cycling Activity Count",
     "Cycling Distance (km)", "Strength Activity Count", "Strength Duration",
     "Cardio Activity Count", "Cardio Duration", # HRV (ms) moved to after Sleep Length
+    "Swim Activity Count", "Swim Distance (km)", "Swim Laps", "Swim Duration (min)",
+    "Pool Swim Count", "Open Water Swim Count", "Average SWOLF", "Total Strokes",
     "Tennis Activity Count", "Tennis Activity Duration"
 ]
 
@@ -56,6 +58,14 @@ HEADER_TO_ATTRIBUTE_MAP = {
     "Strength Duration": "strength_duration",
     "Cardio Activity Count": "cardio_activity_count",
     "Cardio Duration": "cardio_duration",
+    "Swim Activity Count": "swim_activity_count",
+    "Swim Distance (km)": "swim_distance_km",
+    "Swim Laps": "swim_laps",
+    "Swim Duration (min)": "swim_duration_min",
+    "Pool Swim Count": "pool_swim_count",
+    "Open Water Swim Count": "open_water_swim_count",
+    "Average SWOLF": "avg_swolf",
+    "Total Strokes": "total_strokes",
     "HRV (ms)": "overnight_hrv",
     "HRV Status": "hrv_status",
     "Tennis Activity Count": "tennis_activity_count",

--- a/src/sheets_client.py
+++ b/src/sheets_client.py
@@ -69,6 +69,8 @@ class GoogleSheetsClient:
             'Cycling Activity Count', 'Cycling Distance',
             'Strength Activity Count', 'Strength Duration',
             'Cardio Activity Count', 'Cardio Duration',
+            'Swim Activity Count', 'Swim Distance (km)', 'Swim Laps', 'Swim Duration (min)',
+            'Pool Swim Count', 'Open Water Swim Count', 'Average SWOLF', 'Total Strokes',
             'Tennis Activity Count', 'Tennis Activity Duration' # Added Tennis
         ]
         
@@ -120,6 +122,14 @@ class GoogleSheetsClient:
                 metric.strength_duration,
                 metric.cardio_activity_count,
                 metric.cardio_duration,
+                metric.swim_activity_count,
+                metric.swim_distance_km,
+                metric.swim_laps,
+                metric.swim_duration_min,
+                metric.pool_swim_count,
+                metric.open_water_swim_count,
+                metric.avg_swolf,
+                metric.total_strokes,
                 metric.tennis_activity_count, # Added Tennis
                 metric.tennis_activity_duration # Added Tennis
             ]

--- a/tests/test_swim_metrics.py
+++ b/tests/test_swim_metrics.py
@@ -1,0 +1,50 @@
+import asyncio
+from datetime import date
+from src.garmin_client import GarminClient
+
+
+def test_swim_metrics_aggregated(monkeypatch):
+    gc = GarminClient("email", "password")
+    gc._authenticated = True
+
+    activity = {
+        'activityType': {'typeKey': 'pool_swim', 'parentTypeId': 17},
+        'distance': 500,  # meters
+        'duration': 900,  # seconds
+        'lapCount': 20,
+        'activityId': 123,
+    }
+
+    monkeypatch.setattr(gc.client, 'get_stats_and_body', lambda d: {})
+    monkeypatch.setattr(gc.client, 'get_sleep_data', lambda d: {})
+    monkeypatch.setattr(gc.client, 'get_activities_by_date', lambda s, e: [activity])
+    monkeypatch.setattr(gc.client, 'get_user_summary', lambda d: {})
+    monkeypatch.setattr(gc.client, 'get_training_status', lambda d: {})
+
+    async def fake_hrv(self, iso):
+        return None
+
+    monkeypatch.setattr(GarminClient, '_fetch_hrv_data', fake_hrv, raising=False)
+
+    monkeypatch.setattr(
+        gc.client,
+        'get_activity',
+        lambda aid: {
+            'summaryDTO': {
+                'avgSwolf': 40,
+                'totalNumberOfStrokes': 300,
+                'numberOfLaps': 20,
+            }
+        },
+    )
+
+    metrics = asyncio.run(gc.get_metrics(date(2023, 1, 1)))
+
+    assert metrics.swim_activity_count == 1
+    assert metrics.swim_distance_km == 0.5
+    assert metrics.swim_duration_min == 15
+    assert metrics.swim_laps == 20
+    assert metrics.pool_swim_count == 1
+    assert metrics.open_water_swim_count == 0
+    assert metrics.avg_swolf == 40
+    assert metrics.total_strokes == 300


### PR DESCRIPTION
## Summary
- aggregate swim activities including distance, laps, duration, type counts, SWOLF, and strokes
- expose swim metrics in CSV headers and Google Sheet sync
- cover swim aggregation with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a2ba79308333ae455cd6a1ab1834